### PR TITLE
Convert LISTEN_PORT to an integer to prevent type error

### DIFF
--- a/fail2ban_exporter.py
+++ b/fail2ban_exporter.py
@@ -9,7 +9,7 @@ from prometheus_client.core import REGISTRY, GaugeMetricFamily
 
 
 addr = getenv('LISTEN_ADDRESS', 'localhost')
-port = getenv('LISTEN_PORT', 9180)
+port = int(getenv('LISTEN_PORT', 9180))
 path = getenv('EXEC_PATH', '/usr/bin/')
 cmd = "{path}fail2ban-client status {service}"
 comp = compile(r'\s([a-zA-Z\s]+):\t([a-zA-Z0-9-,\s]+)\n')


### PR DESCRIPTION
When you specify the `LISTEN_PORT` environment variable Python will receive it as a string, and you'll receive this error:

```python
Traceback (most recent call last):
  File "fail2ban_exporter.py", line 42, in <module>
    start_http_server(port, addr)
  File "/usr/local/lib/python3.5/dist-packages/prometheus_client/exposition.py", line 181, in start_http_server
    httpd = _ThreadingSimpleServer((addr, port), CustomMetricsHandler)
  File "/usr/lib/python3.5/socketserver.py", line 440, in __init__
    self.server_bind()
  File "/usr/lib/python3.5/http/server.py", line 138, in server_bind
    socketserver.TCPServer.server_bind(self)
  File "/usr/lib/python3.5/socketserver.py", line 454, in server_bind
    self.socket.bind(self.server_address)
TypeError: an integer is required (got type str)
```

I've fixed the issue by converting the port to an integer.