### PR TITLE
Added a fail2ban.service systemd Unit dependency

### DIFF
--- a/fail2ban_exporter.service
+++ b/fail2ban_exporter.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=fail2ban Prometheus exporter
-Wants=network-online.target
-After=network-online.target
+Wants=network-online.target fail2ban.service
+After=network-online.target fail2ban.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
The systemd unit starts the exporter whereas fail2ban did not completly
start, the socket file is not here and the exporter fails.